### PR TITLE
Added user email to config

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,6 +102,7 @@ function isTravis() {
 
 function npmAddUser(npmUser, callback) {
     npm.registry.adduser(npmUser.username, npmUser.password, npmUser.email, function(err) {
+        npm.config.set("email", npmUser.email, "user");
         callback(err);
     });
 }


### PR DESCRIPTION
When doing npm.registry.adduser, the details do not get added to local npm.config. Username and password (with auth) are added to npm.config on the method, but not the email address. Hence, when there is no local ~/.npmrc file, npm.commands.publish is not able to find an email, and the publish fails. This is true in cases on CI (travis) where a new machine does not have a local ~/.npmrc file. This change adds the email to the npm.config, that can then be used by npm.commands.publish, to push the repository successfully.
