### PR TITLE
Fix handling of --tag option: it must be set on npm.load()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-  - 0.11
+  - 0.12
+	- 4.2
+  - 4
+	- 5
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - 0.12
-  - 4.2
   - 4
   - 5
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
   - 0.12
-	- 4.2
+  - 4.2
   - 4
-	- 5
+  - 5
 notifications:
   email:
     on_success: never

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The options that you can use with publish are:
 * --on-minor  Publishes on minor version changes.
 * --on-patch  Publishes on patch version changes.
 * --on-build  Publishes on build version changes.
+* --test      Prints the versions of the packages and whether it would publish.
 * --tag <tag> Publishes the change with the given tag. (npm defaults to 'latest')
 * --version   Print the version of publish.
 * --help      Print the help of publish.

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -1,15 +1,25 @@
 #!/usr/bin/env node
 
-var publish = require('../index');
-    nopt = require("nopt"),
-    knownOpts = { 'on-major':Boolean, 'on-minor':Boolean, 'on-patch':Boolean, 'on-build':Boolean,
-                  'tag':String },
-    shorthands = { "?":["--help"], "v":["--version"]},
+var publish = require('../index'),
+    nopt = require('nopt');
+
+var knownOpts = {
+        'on-major': Boolean,
+        'on-minor': Boolean,
+        'on-patch': Boolean,
+        'on-build': Boolean,
+				'test':     Boolean,
+        'tag':      String
+    },
+    shorthands = {
+        '?': ['--help'],
+        'v': ['--version']
+    },
     options = nopt(knownOpts, shorthands);
 
 if (options.version) {
-    console.log(require("../package.json").version)
-    process.exit(0)
+    console.log(require('../package.json').version);
+    process.exit(0);
 }
 
 if (options.help) {
@@ -28,17 +38,19 @@ if (options.help) {
      --on-build  Publishes on build version changes.
      --tag <tag> Publishes the change with the given tag.
                  (npm defaults to 'latest')
+		 --test      Prints the versions of the packages
+		             and whether it would publish.
      --version   Print the version of publish.
      --help      Print this help.
 
      Please report bugs!  https://github.com/cmanzana/node-publish/issues
 
      */
-    }.toString().split(/\n/).slice(1, -2).join("\n"));
+    }.toString().split(/\n/).slice(1, -2).join('\n'));
     process.exit(0);
 }
 
-publish.start(function(err) {
+publish.start(options.tag, function(err) {
     if (err) {
         handleError(err);
     }
@@ -53,6 +65,6 @@ publish.start(function(err) {
 });
 
 function handleError(err) {
-    log.error(err);
+    console.error(err);
     process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "CI"
   ],
   "devDependencies": {
-    "mocha": "1.3.0"
+    "mocha": "^2.4.5"
   },
   "author": "Carlos Manzanares <carlos.manzanares@gmail.com>",
   "license": "MIT"

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,11 +1,16 @@
 var assert = require('assert'),
     pkg = require('../package.json'),
-    figaro = require('../index'),
-    npm = require('npm');
-
-log.level = 'silent';
+    figaro = require('../index');
 
 describe('publish', function () {
+    before(function (done) {
+        // setup default npm using our start function
+        // note: npm.load() only has an affect the first time it's called in a process
+        figaro.start(null, function(e) {
+            assert.ifError(e);
+            done();
+        });
+    });
     describe('#shouldPublish', function () {
         it('should publish because local version is higher than remote version', function () {
             assert.ok(figaro.shouldPublish(null, '1.3.5', '1.3.4'));
@@ -41,46 +46,17 @@ describe('publish', function () {
 
     describe('#remoteVersion', function() {
         it('should provide the remote version of this module', function(done) {
-            figaro.start(function(e) {
-                assert.ok(!e);
-                figaro.remoteVersion(pkg, function(err, remoteVersion) {
-                    assert.ok(!err);
-                    assert.ok(remoteVersion);
-                    done();
-                });
+            figaro.remoteVersion(pkg, function(err, remoteVersion) {
+                assert.ifError(err);
+                assert.ok(remoteVersion);
+                done();
             });
         });
         it('should report an error because module not found', function (done) {
-            figaro.start(function (e) {
-                assert.ok(!e);
-                figaro.remoteVersion({'name':'mysuperbogusnamethatcannotbefoundpublishedanywhere'}, function (err, remoteVersion) {
-                    assert.ok(err);
-                    done();
-                });
+            figaro.remoteVersion({'name':'mysuperbogusnamethatcannotbefoundpublishedanywhere'}, function (err, remoteVersion) {
+                assert.ok(err);
+                done();
             });
         });
     });
-
-    describe('#publishTag', function() {
-        var configedTag;
-        before(function(done) {
-            npm.load({}, function (err) {
-                configedTag = npm.config.get('tag');
-                done(err);
-            });
-        });
-        afterEach(function() {
-            npm.config.set('tag', configedTag);
-        });
-        it('should use the default config value when not provided', function(done) {
-            figaro.npmSetPublishTag({});
-            assert.equal(npm.config.get('tag'), configedTag);
-            done();
-        });
-        it('should set the tag provided', function(done) {
-            figaro.npmSetPublishTag({ 'tag': 'beta'});
-            assert.equal(npm.config.get('tag'), 'beta');
-            done();
-        })
-    })
 });

--- a/test/outside-in.js
+++ b/test/outside-in.js
@@ -34,3 +34,19 @@ describe('publish', function () {
         });
     });
 });
+
+// older versions of node did not support String.includes(), Polyfill from MDN:
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Polyfill
+if (!String.prototype.includes) {
+  String.prototype.includes = function(search, start) {
+    if (typeof start !== 'number') {
+      start = 0;
+    }
+    
+    if (start + search.length > this.length) {
+      return false;
+    } else {
+      return this.indexOf(search, start) !== -1;
+    }
+  };
+}

--- a/test/outside-in.js
+++ b/test/outside-in.js
@@ -1,0 +1,36 @@
+var assert = require('assert'),
+    path = require('path'),
+    spawn = require('child_process').spawn;
+
+describe('publish', function () {
+    var script = path.resolve(__dirname, '..', 'bin', 'publish.js');
+    var opts = {
+      cwd: path.resolve(__dirname, '..')
+    };
+    describe('#publishTag', function () {
+        it('should use the default config value when not provided', function (done) {
+            var testTagDefault = spawn(script, ['--test'], opts),
+                output = "";
+						testTagDefault.stderr.on('data', function (data) {
+                output += data;
+            });
+            testTagDefault.on('close', function (code) {
+								assert.ok(!output.includes('Using tag'), 'The output included "Using tag":\n' + output);
+								assert.ifError(code, 'Unexpected error code: ' + code);
+                done();
+            });
+        });
+        it('should set the tag provided', function (done) {
+            var testTagSet = spawn(script, ['--test', '--tag', 'foo'], opts),
+                output = "";
+						testTagSet.stderr.on('data', function (data) {
+                output += data;
+            });
+            testTagSet.on('close', function (code) {
+								assert.ok(output.includes('Using tag foo'), 'The output did not include "Using tag foo":\n' + output);
+								assert.ok(code, 'Unexpected error code: ' + code);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
- `{ tag: 'whatever' }` must be passed to the `npm.load()` function for it to fully take effect
- required a new kind of tests for that option (**test/outside-in.js**)
- added new "--test" option to support running publish without actually doing the publish
- also updated mocha dependency and fixed some other failing tests

as promised in issue #4
